### PR TITLE
fix: corrected successful subscription email template

### DIFF
--- a/email_templates/subSuccessful.html
+++ b/email_templates/subSuccessful.html
@@ -26,7 +26,7 @@
      <!-- NOTE: USE DOUBLE CURLY BRACES TO WRAP THE VARIABLE. Dev.to is not letting me do so  and remove this comment-->
       <p>We look forward to giving you a great experience from our webapp. We will notify you whenever a new blog is posted on our site and keep you informed about improvements and new functionalities added to our blog site.
       </p>
-      <p>If you have any questions or need assistance, or you have suggestions on how to improve your experience with our app, please don't hesitate to contact our <a href="shadesblogapp@gmail.com">support team</a>.</p>
+      <p>If you have any questions or need assistance, or you have suggestions on how to improve your experience with our app, please don't hesitate to contact our <a href="mailto:shadesblogapp@gmail.com">support team</a>.</p>
       <p>Best regards,<br />Shade's Blog Team</p>
     </div>
     <div class='footer'>


### PR DESCRIPTION
This PR corrects the contact support email link in the email template sent on successful subscription to app's newsletter.